### PR TITLE
Enable NVFP4 quantization via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ We also provide an example [colab notebook](https://colab.research.google.com/gi
 - `--rotate`: Whether we want to rotate the model
 - `--optimized_rotation_path`: The checkpoint path of optimized rotation; Use random rotation if path is not given
 
+### NVFP4 Quantization
+
+Set the environment variable `USE_NVFP4=1` to enable NVFP4 quantization for activations and weights. Leave it unset to use the original quantization format.
+
  
 ## Quantized Models
  | Model | LLaMA-3 8B | | LLaMA-3 70B | | LLaMA-2 7B | | LLaMA-2 13B | | LLaMA-2 70B | | 

--- a/train_utils/quant_linear.py
+++ b/train_utils/quant_linear.py
@@ -8,6 +8,7 @@
 import torch
 import torch.nn as nn
 from torch._tensor import Tensor
+import os
 
 
 class QuantizeLinear(nn.Linear):
@@ -50,7 +51,8 @@ class QuantizeLinear(nn.Linear):
             weight = self.weight
         if hasattr(self, "quantizer"):
             dtype = weight.dtype
-            self.quantizer.find_params(weight.data)
+            if not (os.getenv("USE_NVFP4", "0") == "1" and self.quantizer.bits == 4):
+                self.quantizer.find_params(weight.data)
             weight = self.quantizer.quantize(weight).to(dtype)
 
         return nn.functional.linear(input, weight, self.bias)


### PR DESCRIPTION
## Summary
- implement NVFP4 quantization helper in `utils/quant_utils.py`
- enable activation and weight quantization to use NVFP4 when `USE_NVFP4=1`
- skip scale calculation when NVFP4 is enabled
- document `USE_NVFP4` environment variable in README

## Testing
- `python -m py_compile utils/quant_utils.py train_utils/quant_linear.py`

------
https://chatgpt.com/codex/tasks/task_e_68629002519c833284cbafe15f3f6a8b