### PR TITLE
Add evaluation script only

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ To obtain ExecuTorch-compatible quantized models, you can use the following scri
 * `bash scripts/32_eval_ptq_executorch.sh $model_name`
 
 We also provide an example [colab notebook](https://colab.research.google.com/gist/zxdmike/abbb2c9b0d1fd1f4ed8cdae8c02180f4) to train and export ExecuTorch compatiable Llama 3.2 models
+
 ### Note
 * If using GPTQ quantization method in Step 2 for quantizing both weight and activations, we optimize the rotation matrices with respect to a network where only activations are quantized.   
   e.g. `bash 10_optimize_rotation.sh meta-llama/Llama-2-7b 16 4 4` followed by `bash 2_eval_ptq.sh meta-llama/Llama-2-7b 4 4 4` with the `--optimized_rotation_path` pointing to the rotation optimized for W16A4KV4.

--- a/eval_tasks.py
+++ b/eval_tasks.py
@@ -1,0 +1,39 @@
+import argparse
+import torch
+from transformers import LlamaTokenizerFast
+from eval_utils.modeling_llama import LlamaForCausalLM
+from lm_eval import evaluator
+
+
+def load_model(model_path: str, base_model: str):
+    config = LlamaForCausalLM.from_pretrained(base_model).config
+    model = LlamaForCausalLM.from_pretrained(base_model, config=config)
+    state_dict = torch.load(model_path, map_location="cpu")
+    model.load_state_dict(state_dict)
+    model.to("cuda")
+    tokenizer = LlamaTokenizerFast.from_pretrained(base_model)
+    tokenizer.pad_token = tokenizer.eos_token
+    return model, tokenizer
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate saved SpinQuant model")
+    parser.add_argument("--model_path", type=str, required=True, help="Path to saved model state_dict")
+    parser.add_argument("--base_model", type=str, required=True, help="Base model identifier")
+    parser.add_argument(
+        "--tasks",
+        type=str,
+        default="arc_challenge,arc_easy,boolq,hellaswag,openbookqa,piqa,winogrande,mmlu",
+        help="Comma separated list of tasks to evaluate",
+    )
+    args = parser.parse_args()
+
+    model, tokenizer = load_model(args.model_path, args.base_model)
+
+    task_list = [t.strip() for t in args.tasks.split(",")]
+    results = evaluator.simple_evaluate(model=model, tokenizer=tokenizer, tasks=task_list)
+    print(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirement.txt
+++ b/requirement.txt
@@ -3,3 +3,4 @@ accelerate==0.34.2
 datasets==2.20.0
 sentencepiece
 tensorboardX
+lm-eval==0.4.1


### PR DESCRIPTION
## Summary
- keep the helper `eval_tasks.py` for evaluating saved models
- remove CLI options for saving/loading full models from `ptq.py`
- drop related README documentation

## Testing
- `python -m py_compile eval_tasks.py ptq.py utils/process_args.py`


------
https://chatgpt.com/codex/tasks/task_e_6862907f2d5c8332ad5b86a8a16b2c7b